### PR TITLE
Fix duplicate dependencies in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,18 +46,6 @@
             <version>8.3.0</version>
         </dependency>
 
-        <!-- SpringDoc Swagger 3.x compatible -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-
         <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -76,14 +64,6 @@
             <version>0.11.5</version>
             <scope>runtime</scope>
         </dependency>
-
-        <!-- Lombok (opcional pero útil) -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
-
 
         <!-- Lombok -->
         <dependency>
@@ -113,6 +93,7 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- SpringDoc Swagger 3.x compatible -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>


### PR DESCRIPTION
## Summary
- remove repeated `spring-boot-starter-security` entries
- keep a single Lombok dependency
- keep SpringDoc comment near its dependency

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68800fa5001c832e945de158e2bea149